### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+Copyright (c) 2018 Portainer.io
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ docker run --rm -v portainer_portainer_data:/data portainer/helper-reset-passwor
 # scale back to one the existing Portainer service and use the password above to login
 docker service scale portainer_portainer=1
 ```
+
+## Licensing
+
+Portainer reset password helper is licensed under the zlib license. See [LICENSE](./LICENSE) for reference.


### PR DESCRIPTION
Adding the standard Portainer license file

Copied from https://github.com/portainer/portainer/blob/develop/LICENSE